### PR TITLE
Fix the use of identifierParamName in save-form.js

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save-form.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save-form.js
@@ -97,7 +97,7 @@ define(
                     if (this.config.identifierParamName === 'undefined') {
                         identifierProperty = undefined;
                     } else {
-                        identifierProperty = this.configure.identifierParamName;
+                        identifierProperty = this.config.identifierParamName;
                     }
                 }
                 const entityId = propertyAccessor.accessProperty(this.getFormData(), entityIdProperty, '');


### PR DESCRIPTION
I have figured out an issue during creating my custom entity. I wasn't able to define identifierParamName for save-form.js. Now it is hardcoded as 'identifier' because of bug in save-form.js. I have prepared PR with fix the use of the identifierParamName passed to the save-form.js config.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
